### PR TITLE
Update ckeditor-iframe.css for WDN 5.0 and make @import relative to docroot

### DIFF
--- a/README
+++ b/README
@@ -2,3 +2,6 @@ Based on the 5.0 version of the UNLedu Web Framework at http://wdn.unl.edu/
 
 Requirements:
   - The 'wdn' directory from the UNLedu Web Framework project (https://github.com/unl/wdntemplates) containing template dependents (the CSS and JS) needs to be located (sym-link/shortcut is o.k.) at the root of the Drupal install.
+
+CKEditor integration:
+  - This theme includes a 'unl_five_ckeditor' sub-module. When enabled, this sub-module provides UNLedu Web Framework CSS files to CKEditor.

--- a/css/ckeditor-iframe.css
+++ b/css/ckeditor-iframe.css
@@ -1,5 +1,3 @@
-@import url("../../../wdn/templates_5.0/css/all.css");
-
 body {
   font-family: inherit;
   font-size: 16px;

--- a/unl_five.info.yml
+++ b/unl_five.info.yml
@@ -3,6 +3,9 @@ type: theme
 description: 'This theme tracks the 5.0.x version of the UNLedu Web Framework.'
 core: 8.x
 
+dependencies:
+  - unl_five_ckeditor:unl_five_ckeditor
+
 libraries:
   - unl_five/global-styling
   - unl_five/idm

--- a/unl_five.info.yml
+++ b/unl_five.info.yml
@@ -3,9 +3,6 @@ type: theme
 description: 'This theme tracks the 5.0.x version of the UNLedu Web Framework.'
 core: 8.x
 
-dependencies:
-  - unl_five_ckeditor:unl_five_ckeditor
-
 libraries:
   - unl_five/global-styling
   - unl_five/idm

--- a/unl_five_ckeditor/unl_five_ckeditor.info.yml
+++ b/unl_five_ckeditor/unl_five_ckeditor.info.yml
@@ -1,0 +1,9 @@
+name: 'UNLedu 5.0 CKEditor'
+description: 'Provides CKEditor integration for UNLedu 5.0 theme.'
+package: UNL
+
+type: module
+core: 8.x
+
+dependencies:
+  - drupal:ckeditor

--- a/unl_five_ckeditor/unl_five_ckeditor.module
+++ b/unl_five_ckeditor/unl_five_ckeditor.module
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Code for unl_five that can't be in a theme.
+ */
+
+/**
+ * Implements hook_ckeditor_css_alter().
+ *
+ * Note: hook_ckeditor_css_alter() only executes for modules and the
+ * active theme; thus, this code cannot run from unl_five.theme because
+ * the admin theme will be active when CKEditor is loaded.
+ */
+function unl_five_ckeditor_ckeditor_css_alter(&$css, $editor) {
+  // These WDN CSS files cannot be reliably loaded in unl_five.info.yml
+  // as a ckeditor_stylesheets library because CSS's @import rule can only
+  // load them relative to the theme, not relative to the docroot.
+  // The theme may be loaded from /web/themes or /web/themes/contrib,
+  // so relative paths won't work. It's also possible that Drupal may be
+  // executed out of a sub-directory namespace
+  // (e.g. http://example.unl.edu/workspace/project-herbie/web/), so
+  // loading relative to the domain root won't work either. It must relative
+  // to Drupal's base url.
+  $css[] = 'wdn/templates_5.0/css/core.css';
+  $css[] = 'wdn/templates_5.0/css/deprecated.css';
+}


### PR DESCRIPTION
There are actually three issues, but we'll tackle them all in one issue/commit:

## The `all.css` file doesn't exist in WDN 5.0; it's now `core.css`:

Propose changing 

`@import url("../../../wdn/templates_5.0/css/all.css");`

to

`@import url("../../../wdn/templates_5.0/css/core.css");`

## The `@import` url in `ckeditor-iframe.css` is relative to the theme, not docroot

Currently, the `@import` url assumes the theme is installed in `/web/themes` when it may be also be installed in `/web/theme/contrib` (or elsewhere), as is the case with project-herbie. The proposed resolution is to make the url relative to the docroot:

`@import url("../../../wdn/templates_5.0/css/core.css");`

to

`@import url("/wdn/templates_5.0/css/core.css");`

## Also load deprecated.css

Currently, we're loading `core.css`, but not `deprecated.css`

Propose adding:

`@import url("/wdn/templates_5.0/css/deprecated.css");`

I noticed this last one because the table styles from the front end weren't appearing in rich text editor.