### PR TITLE
'menu-item--active' Not Consistently Applied

### DIFF
--- a/templates/book-tree.html.twig
+++ b/templates/book-tree.html.twig
@@ -30,6 +30,7 @@
             item.is_expanded ? 'menu-item--expanded',
             item.is_collapsed ? 'menu-item--collapsed',
             item.in_active_trail ? 'menu-item--active-trail',
+            item.is_active ? 'menu-item--active',
             'dcf-p-0',
             'dcf-m-0'
           ]
@@ -37,7 +38,7 @@
         <li{{ item.attributes.addClass(classes) }}>
           {%
             set classes = [
-              item.in_active_trail and not item.below ? 'menu-item--active dcf-bl-2 dcf-br-2 dcf-bl-solid dcf-br-solid unl-bl-scarlet unl-br-scarlet',
+              item.is_active ? 'dcf-bl-2 dcf-br-2 dcf-bl-solid dcf-br-solid unl-bl-scarlet unl-br-scarlet',
               'dcf-txt-decor-hover',
               'dcf-d-block'
             ]


### PR DESCRIPTION
The book menu block, which is rendered with book-tree.html.twig, does not consistently apply the 'menu-item--active' to active menu items.

Example hierarchy:
- Book Page 1
  - Book Page 1.1
    - Book Page 1.1.1
  - Book Page 2.1

When on the page for Book Page 1.1.1, the 'menu-item--active' is present:
```
<li class="menu-item menu-item--active-trail dcf-p-0 dcf-m-0">
  <a href="/book-page-1/book-page-11/book-page-111" class="menu-item--active dcf-bl-2 dcf-br-2 dcf-bl-solid dcf-br-solid unl-bl-scarlet unl-br-scarlet dcf-txt-decor-hover dcf-d-block" hreflang="en">Book Page 1.1.1</a>
</li>
```
When on the page for Book Page 1.1, the 'menu-item--active' is not present:
```
<li class="menu-item menu-item--expanded menu-item--active-trail dcf-p-0 dcf-m-0">
  <a href="/book-page-1/book-page-11" class="dcf-txt-decor-hover dcf-d-block" hreflang="en">Book Page 1.1</a>
    <ul class="dcf-list-bare dcf-m-0">
      <li class="menu-item dcf-p-0 dcf-m-0">
        <a href="/book-page-1/book-page-11/book-page-111" class="dcf-txt-decor-hover dcf-d-block" hreflang="en">Book Page 1.1.1</a>
      </li>
  </ul>
</li>
```