### PR TITLE
unl_five_preprocess_form_element() should check if $variables['attributes']['class'] exists

### DIFF
--- a/unl_five.theme
+++ b/unl_five.theme
@@ -278,7 +278,7 @@ function unl_five_preprocess_form_element(&$variables) {
   }
 
   // Add 'dcf-form-controls-inline' class as appropriate.
-  if (in_array('webform-element--title-inline', $variables['attributes']['class'])) {
+  if (isset($variables['attributes']['class']) && in_array('webform-element--title-inline', $variables['attributes']['class'])) {
     $variables['attributes']['class'][] = 'dcf-form-controls-inline';
   }
 


### PR DESCRIPTION
In `unl_five_preprocess_form_element()`, the code attempts to use `$variables['attributes']['class']` in `in_array()` without checking if the index exists first:
```
  // Add 'dcf-form-controls-inline' class as appropriate.
  if (in_array('webform-element--title-inline', $variables['attributes']['class'])) {
    $variables['attributes']['class'][] = 'dcf-form-controls-inline';
  }
```
This can result in the following notice/warning:
```
Notice: Undefined index: class in unl_five_preprocess_form_element() (line 281 of /app/web/themes/contrib/unl_five/unl_five.theme)
```
```
Warning: in_array() expects parameter 2 to be array, null given in unl_five_preprocess_form_element() (line 281 of /app/web/themes/contrib/unl_five/unl_five.theme)
```

## Proposed change:
```
  // Add 'dcf-form-controls-inline' class as appropriate.
+ if (isset($variables['attributes']['class']) && in_array('webform-element--title-inline', $variables['attributes']['class'])) {
- if (in_array('webform-element--title-inline', $variables['attributes']['class'])) {
    $variables['attributes']['class'][] = 'dcf-form-controls-inline';
  }
```
