### PR TITLE
Set base theme

### DIFF
--- a/unl_five.info.yml
+++ b/unl_five.info.yml
@@ -1,5 +1,6 @@
 name: UNLedu 5.0
 type: theme
+base theme: stable
 description: 'This theme tracks the 5.0.x version of the UNLedu Web Framework.'
 core: 8.x
 


### PR DESCRIPTION
[The base theme property in theme .info.yml files is now required](https://www.drupal.org/node/3066038)

Beginning in Drupal 8.8.0, it will be necessary to declare the base theme as stable.

From [8.8.0 release notes](https://www.drupal.org/project/drupal/releases/8.8.0):
> In Drupal 8, if a theme does not specify a base theme, Stable is used automatically. Starting with Drupal 9, a new stable base theme will be added to each major version with the latest markup provided by modules, and the old stable base theme will be deprecated. To facilitate this and avoid unintended regressions, the automatic base theme fallback is now deprecated and the base theme property will be required starting with Drupal 9.0.0. To remain compatible with Drupal 9, themes that use Stable as their base theme should now explicitly add a base theme to their info files. See the change record on requiring the base theme property for examples.