### PR TITLE
Add support for Layout Builder

### DIFF
--- a/unl_five.theme
+++ b/unl_five.theme
@@ -264,6 +264,22 @@ function unl_five_is_request_group_front() {
 function unl_five_form_alter(&$form, FormStateInterface &$form_state, $form_id) {
   // Add 'dcf-form' class to form.
   $form['#attributes']['class'][] = 'dcf-form';
+
+  // Target Layout Builder forms.
+  // e.g. form_id ends in '_layout_builder_form'.
+  if (strpos(strrev($form_id), strrev('_layout_builder_form')) === 0) {
+    // Add DCF button classes.
+    $form['actions']['submit']['#attributes']['class'][] = 'dcf-btn';
+    $form['actions']['submit']['#attributes']['class'][] = 'dcf-btn-primary';
+    $form['actions']['discard_changes']['#attributes']['class'][] = 'dcf-btn';
+    $form['actions']['discard_changes']['#attributes']['class'][] = 'dcf-btn-secondary';
+    $form['actions']['revert']['#attributes']['class'][] = 'dcf-btn';
+    $form['actions']['revert']['#attributes']['class'][] = 'dcf-btn-secondary';
+    $form['actions']['move_sections']['#attributes']['class'][] = 'dcf-btn';
+    $form['actions']['move_sections']['#attributes']['class'][] = 'dcf-btn-secondary';
+    // Add margin-top to preview toggle.
+    $form['actions']['preview_toggle']['#attributes']['class'][] = 'dcf-mt-4';
+  }
 }
 
 /**

--- a/unl_five.theme
+++ b/unl_five.theme
@@ -271,14 +271,18 @@ function unl_five_form_alter(&$form, FormStateInterface &$form_state, $form_id) 
     // Add DCF button classes.
     $form['actions']['submit']['#attributes']['class'][] = 'dcf-btn';
     $form['actions']['submit']['#attributes']['class'][] = 'dcf-btn-primary';
+    $form['actions']['submit']['#attributes']['class'][] = 'dcf-mb-2';
     $form['actions']['discard_changes']['#attributes']['class'][] = 'dcf-btn';
     $form['actions']['discard_changes']['#attributes']['class'][] = 'dcf-btn-secondary';
+    $form['actions']['discard_changes']['#attributes']['class'][] = 'dcf-mb-2';
     $form['actions']['revert']['#attributes']['class'][] = 'dcf-btn';
     $form['actions']['revert']['#attributes']['class'][] = 'dcf-btn-secondary';
+    $form['actions']['revert']['#attributes']['class'][] = 'dcf-mb-2';
     $form['actions']['move_sections']['#attributes']['class'][] = 'dcf-btn';
     $form['actions']['move_sections']['#attributes']['class'][] = 'dcf-btn-secondary';
+    $form['actions']['move_sections']['#attributes']['class'][] = 'dcf-mb-2';
     // Add margin-top to preview toggle.
-    $form['actions']['preview_toggle']['#attributes']['class'][] = 'dcf-mt-4';
+    $form['actions']['preview_toggle']['#attributes']['class'][] = 'dcf-mt-2';
   }
 }
 


### PR DESCRIPTION
Layout Builder uses the front-end theme to render its view mode form. By default, this is what is looks like in unl_five:

![Screen Shot 2019-12-13 at 2 22 37 PM](https://user-images.githubusercontent.com/1521132/70833931-99d3ae80-1dbe-11ea-9653-d5cc84606bd7.png)

These are also the proposed changes.