### PR TITLE
Remove unl_five_preprocess_breadcrumb()

### DIFF
--- a/README
+++ b/README
@@ -3,5 +3,8 @@ Based on the 5.0 version of the UNLedu Web Framework at http://wdn.unl.edu/
 Requirements:
   - The 'wdn' directory from the UNLedu Web Framework project (https://github.com/unl/wdntemplates) containing template dependents (the CSS and JS) needs to be located (sym-link/shortcut is o.k.) at the root of the Drupal install.
 
+Breadcrumbs:
+  - Previous versions of unl_five included breadcrumbs functionality. This code has been moved to the unl_breadcrumbs project in the 8.x-1.x branch.
+
 CKEditor integration:
   - This theme includes a 'unl_five_ckeditor' sub-module. When enabled, this sub-module provides UNLedu Web Framework CSS files to CKEditor.

--- a/unl_five.theme
+++ b/unl_five.theme
@@ -177,33 +177,6 @@ function unl_five_preprocess_book_navigation(&$variables) {
 }
 
 /**
- * Implements template_preprocess_breadcrumb().
- */
-function unl_five_preprocess_breadcrumb(&$variables) {
-  if ($variables['breadcrumb']) {
-    $variables['breadcrumb'][0] = [
-      'text' => 'Nebraska',
-      'url' => 'https://www.unl.edu/',
-    ];
-
-    if (unl_five_get_current_group()) {
-      // @todo: There should probably be a way to inject "intermediate" crumbs
-    }
-
-    // Append current page.
-    $request = \Drupal::request();
-    $route_match = \Drupal::routeMatch();
-    $page_title = \Drupal::service('title_resolver')->getTitle($request, $route_match->getRouteObject());
-
-    if (!empty($page_title)) {
-      $variables['breadcrumb'][] = [
-        'text' => $page_title,
-      ];
-    }
-  }
-}
-
-/**
  * Implements template_preprocess_webform_composite_address().
  */
 function unl_five_preprocess_webform_composite_address(&$variables) {


### PR DESCRIPTION
Per unlcms/unl_breadcrumbs#2, this issue is a follow-up to remove `unl_five_preprocess_breadcrumb()`. It's functionality has been replaced by the 8.x-1.x version of the unl_breadcrumbs custom module.