### PR TITLE
Add .dcf-figcaption to <figcaption> elements

### DIFF
--- a/templates/filter-caption.html.twig
+++ b/templates/filter-caption.html.twig
@@ -14,5 +14,5 @@
 #}
 <figure role="group" class="wdn-frame{%- if classes %} {{ classes }}{%- endif %}">
   {{ node }}
-  <figcaption>{{ caption }}</figcaption>
+  <figcaption class="dcf-figcaption">{{ caption }}</figcaption>
 </figure>


### PR DESCRIPTION
In order for DCF styling to be applied to `<figcaption>` elements, we need to add the `.dcf-figcaption` class.