### PR TITLE
Load core/drupal.autocomplete library with amd unl_five library

### DIFF
--- a/unl_five.libraries.yml
+++ b/unl_five.libraries.yml
@@ -23,6 +23,7 @@ amd:
     js/amd-enable.js: {}
   dependencies:
     - core/jquery.form
+    - core/drupal.autocomplete
 
 idm:
   version: VERSION


### PR DESCRIPTION
It appears we need to load the `core/drupal.autocomplete` library when we load unl_five's `amd` library. When an autocomplete field is rendered in unl_five, the autocomplete functionality doesn't work. The following error messages are generated:

```
drupal.js?v=8.8.1:13 Uncaught TypeError: $(...).find(...).removeOnce(...).autocomplete is not a function
    at Object.detach (<anonymous>:135:79)
    at drupal.js?v=8.8.1:42
    at Array.forEach (<anonymous>)
    at Object.Drupal.detachBehaviors (drupal.js?v=8.8.1:39)
    at Drupal.AjaxCommands.insert (ajax.js?v=8.8.1:536)
    at Drupal.AjaxCommands.openDialog (dialog.ajax.js?v=8.8.1:74)
    at ajax.js?v=8.8.1:439
    at Array.forEach (<anonymous>)
    at Drupal.Ajax.success (ajax.js?v=8.8.1:437)
    at Object.success (ajax.js?v=8.8.1:234)

drupal.js?v=8.8.1:13 Uncaught TypeError: $autocomplete.autocomplete is not a function
    at Object.attach (<anonymous>:121:23)
    at drupal.js?v=8.8.1:25
    at Array.forEach (<anonymous>)
    at Object.Drupal.attachBehaviors (drupal.js?v=8.8.1:22)
    at HTMLFormElement.<anonymous> (ajax.js?v=8.8.1:560)
    at Function.each (jquery.min.js?v=3.4.1:2)
    at k.fn.init.each (jquery.min.js?v=3.4.1:2)
    at Drupal.AjaxCommands.insert (ajax.js?v=8.8.1:558)
    at Drupal.AjaxCommands.openDialog (dialog.ajax.js?v=8.8.1:74)
    at ajax.js?v=8.8.1:439
```

Loading the `core/drupal.autocomplete` library with unl_five's `amd` library resolves the issue:

```
amd:
  version: VERSION
  js:
    js/amd-disable.js: { weight: -999 }
    js/amd-enable.js: {}
  dependencies:
    - core/jquery.form
+   - core/drupal.autocomplete
```

(This is a bit of a workaround due to how the WDN templates load JS.)