### PR TITLE
Add core/js-cookie as a library dependency

### DIFF
--- a/unl_five.libraries.yml
+++ b/unl_five.libraries.yml
@@ -24,6 +24,7 @@ amd:
   dependencies:
     - core/jquery.form
     - core/drupal.autocomplete
+    - core/js-cookie
 
 idm:
   version: VERSION


### PR DESCRIPTION
In Drupal 8.9.0, jquery.cookie was replaced with js-cookie. A backwards-compatible shim was added for jquery.cookie. See [jquery.cookie replaced with js-cookie](https://www.drupal.org/node/3104677).

This issue seeks to add core/js-cookie as a library dependency.

Background below:

I'm running into an issue on unlcms/project-herbie#47. I'm loading the CodeMirror library for use via AJAX, and it works on 8.8.6 but not on 8.9.0. On 8.9.0, I get the following JS error:

```
Uncaught TypeError: Cannot read property 'defaults' of undefined
    at <anonymous>:531:59
    at <anonymous>:541:3
    at b (js_iDCbqpopv9tGkCn3CoRPqOe8AhfUsrCXQiuW1tx4QAs.js:5)
    at Function.globalEval (js_iDCbqpopv9tGkCn3CoRPqOe8AhfUsrCXQiuW1tx4QAs.js:5)
    at Object.dataFilter (js_iDCbqpopv9tGkCn3CoRPqOe8AhfUsrCXQiuW1tx4QAs.js:5)
    at js_iDCbqpopv9tGkCn3CoRPqOe8AhfUsrCXQiuW1tx4QAs.js:5
    at l (js_iDCbqpopv9tGkCn3CoRPqOe8AhfUsrCXQiuW1tx4QAs.js:5)
    at XMLHttpRequest.<anonymous> (js_iDCbqpopv9tGkCn3CoRPqOe8AhfUsrCXQiuW1tx4QAs.js:5)
    at Object.send (js_iDCbqpopv9tGkCn3CoRPqOe8AhfUsrCXQiuW1tx4QAs.js:5)
    at Function.ajax (js_iDCbqpopv9tGkCn3CoRPqOe8AhfUsrCXQiuW1tx4QAs.js:5)
```

I don't understand what's happening, but it's choking on the new shim file: jquery.cookie.shim.js. If I switch to Bartik, then everything works correctly. If I add core/js-cookie as a library dependency, then it works. I'm wondering if it's not related to the fact that we're also loading jQuery with the UNL templates.