### PR TITLE
Set Z-index on .ui-dialog

### DIFF
--- a/css/components/dialog.css
+++ b/css/components/dialog.css
@@ -1,0 +1,3 @@
+.ui-dialog {
+  z-index: 1260;
+}

--- a/unl_five.libraries.yml
+++ b/unl_five.libraries.yml
@@ -2,6 +2,7 @@ global-styling:
   version: VERSION
   css:
     component:
+      css/components/dialog.css: {}
       css/components/local-tasks.css: {}
       css/components/form.css: {}
       css/components/node-preview.css: {}


### PR DESCRIPTION
[Originally reported by ericras](https://github.com/unlcms/project-herbie/pull/47#issuecomment-649025136)

<img width="379" alt="85573822-d731b800-b5fb-11ea-81a8-09f0497047a1" src="https://user-images.githubusercontent.com/1521132/86053378-0726f400-ba1e-11ea-968e-eac31dba74ff.png">

> Regarding the full screen issue screenshot above:
> 
> Layout Builder Modal uses core modal functionality that utilizes JQuery UI's dialog. It looks at everything that has class "ui-front" and makes the modal's z-index one greater. However, the toolbar doesn't have "ui-front" (and my attempt at patching it to add "ui-front" didn't end up working anyway).
> 
> (I was thinking that https://www.drupal.org/project/drupal/issues/2158943 will impact things in a future 9.x release but on second thought I'm not so sure.)
> 
> It looks like the "solution" in Seven & Bartik is simply .ui-dialog {z-index:1260} in their theme's dialog.css. I think that's the answer - an addition of dialog.css to unl_five with at least that rule in it.