### PR TITLE
unl_five_preprocess_html() causes a fatal error on node revision pages

### DIFF
--- a/unl_five.theme
+++ b/unl_five.theme
@@ -65,9 +65,8 @@ function unl_five_preprocess_html(&$variables) {
   );
 
   // Add node id to the body class.
-  $node = \Drupal::routeMatch()->getParameter('node');
-  if ($node) {
-    $variables['attributes']['class'][] = 'page-node-' . $node->id();
+  if ($nid = \Drupal::routeMatch()->getRawParameter('node')) {
+    $variables['attributes']['class'][] = 'page-node-' . $nid;
   }
 }
 


### PR DESCRIPTION
When attempting to view a node revision, the following error is encountered:

`Error: Call to a member function id() on string in unl_five_preprocess_html() (line 70 of /var/www/html/web/themes/contrib/unl_five/unl_five.theme)`

Steps to reproduce:
1. Create a node (node/add)
1. Edit the node and create a revision (node/[nid]/edit)
1. Attempt to view the revision (node/[nid]/revisions/[vid]/view)

When `\Drupal::routeMatch()->getParameter('node')` is called on a node view page, it returns a node object. When it's called on a revision view page, it returns the node id. The code attempts to execute the `id()` method on the return value regardless. In the case of a revision page, this causes the above fatal error.