### PR TITLE
Add support for Webform 6

### DIFF
--- a/css/components/form.css
+++ b/css/components/form.css
@@ -128,44 +128,87 @@ a.tabledrag-handle .handle {
     padding: 0 !important;
 }
 
-.webform-progress-tracker.progress-tracker {
+.webform-version-5 .webform-progress-tracker.progress-tracker {
     margin-bottom: 2.37em;
 }
 
-.webform-progress-tracker .progress-marker {
+.webform-version-5 .webform-progress-tracker .progress-marker {
     height: 1.77em;
     padding-bottom: 0;
     width: 1.77em;
 }
 
-.webform-progress-tracker .progress-text {
+.webform-version-5 .webform-progress-tracker .progress-text {
     font-size: .63em;
 }
 
-.webform-progress-tracker .progress-step:not(.is-active) .progress-marker,
-.webform-progress-tracker .progress-step:hover .progress-marker,
-.webform-progress-tracker .progress-step::after {
+.webform-version-5 .webform-progress-tracker .progress-step:not(.is-active) .progress-marker,
+.webform-version-5 .webform-progress-tracker .progress-step:hover .progress-marker,
+.webform-version-5 .webform-progress-tracker .progress-step::after {
     background-color: #6b6b68;
 }
 
-.webform-progress-tracker .progress-step:not(:last-child)::after {
+.webform-version-5 .webform-progress-tracker .progress-step:not(:last-child)::after {
     bottom: .84em;
     height: 3px;
     top: .84em;
 }
 
-.webform-progress-tracker .progress-step .progress-text {
+.webform-version-5 .webform-progress-tracker .progress-step .progress-text {
     color: #6b6b68;
     padding-top: .43em;
 }
 
-.webform-progress-tracker .progress-step.is-active .progress-marker,
-.webform-progress-tracker .progress-step.is-active:hover .progress-marker {
+.webform-version-5 .webform-progress-tracker .progress-step.is-active .progress-marker,
+.webform-version-5 .webform-progress-tracker .progress-step.is-active:hover .progress-marker {
     background-color: #d00000;
 }
 
-.webform-progress-tracker .progress-step.is-active .progress-text {
+.webform-version-5 .webform-progress-tracker .progress-step.is-active .progress-text {
     color: inherit;
+}
+
+.webform-version-6 .webform-progress-tracker.progress-tracker {
+    margin-bottom: 2.37em;
+}
+
+
+.webform-version-6 .webform-progress-tracker .progress-marker::before {
+    height: 30px;
+    padding-bottom: 0;
+    width: 30px;
+}
+
+.webform-version-6 .progress-marker::after {
+    top: 13px;
+}
+
+.webform-version-6 .webform-progress-tracker .progress-text {
+    font-size: .63em;
+}
+
+.webform-version-6 .webform-progress-tracker .progress-step::after {
+    background-color: #6b6b68;
+}
+
+.webform-version-6 .webform-progress-tracker .progress-step.is-active .progress-text {
+    color: inherit;
+}
+
+.webform-version-6 .webform-progress-tracker .progress-step.is-complete .progress-marker::before,
+.webform-version-6 .webform-progress-tracker .progress-step.is-complete:hover .progress-marker::before,
+.webform-version-6 .webform-progress-tracker .progress-step.is-complete .progress-marker::after {
+    background-color: #777;
+}
+
+.webform-version-6 .webform-progress-tracker .progress-step.is-complete .progress-marker::before,
+.webform-version-6 .webform-progress-tracker .progress-step.is-complete:hover .progress-marker::before,
+.webform-version-6 .webform-progress-tracker .progress-step.is-complete .progress-marker::after {
+    background-color: #d00000;
+}
+
+.webform-version-6 .progress-step.is-active .progress-marker::before {
+    background-color: #d00000;
 }
 
 .webform-flexbox {

--- a/unl_five.theme
+++ b/unl_five.theme
@@ -237,6 +237,22 @@ function unl_five_form_alter(&$form, FormStateInterface &$form_state, $form_id) 
   // Add 'dcf-form' class to form.
   $form['#attributes']['class'][] = 'dcf-form';
 
+  // If a Webform form, add a class indicating the major version of the
+  // Webform module.
+  if (isset($form['#webform_id'])) {
+    /** @var \Drupal\Core\Extension\ModuleExtensionList */
+    $extension_list = Drupal::service('extension.list.module');
+    if ($extension_list->exists('webform')) {
+      $extension_info = $extension_list->getExtensionInfo('webform');
+      if (strncasecmp($extension_info['version'], "8.x-5", 5) === 0) {
+        $form['#attributes']['class'][] = 'webform-version-5';
+      }
+      elseif (strncasecmp($extension_info['version'], "6.", 2) === 0) {
+        $form['#attributes']['class'][] = 'webform-version-6';
+      }
+    }
+  }
+
   // Target Layout Builder forms.
   // e.g. form_id ends in '_layout_builder_form'.
   if (strpos(strrev($form_id), strrev('_layout_builder_form')) === 0) {


### PR DESCRIPTION
There are some minor changes between Webform 5 and Webform 6. This PR seeks to add Webform 6 support by adding a webform version class to webform versions (e.g. either "webform-version-5" or "webform-version-6"). The progress tracker needs different CSS between the versions.