### PR TITLE
Add support for WDN font-serif plugin

### DIFF
--- a/js/wdn-font-serif.js
+++ b/js/wdn-font-serif.js
@@ -1,0 +1,21 @@
+/**
+ * @file
+ * Initiates the WDN font-serif plugin.
+ */
+
+(function (Drupal) {
+  Drupal.behaviors.wdnFontSerif = {
+    attach: function attach(context, settings) {
+      // Check if WDN object is defined.
+      if ('undefined' !== typeof WDN) {
+        WDN.initializePlugin('font-serif');
+      }
+      // If WDN object isn't defined, then wait for inlineJSReady event.
+      else {
+        window.addEventListener('inlineJSReady', function () {
+          WDN.initializePlugin('font-serif');
+        }, false);
+      }
+    }
+  };
+})(Drupal);

--- a/unl_five.libraries.yml
+++ b/unl_five.libraries.yml
@@ -43,3 +43,8 @@ layout_builder:
   css:
     theme:
       css/layout-builder.css: {}
+
+wdn-font-serif:
+  version: VERSION
+  js:
+    js/wdn-font-serif.js: {}

--- a/unl_five.theme
+++ b/unl_five.theme
@@ -163,6 +163,26 @@ function unl_five_preprocess_block(&$variables) {
 }
 
 /**
+ * Implements template_preprocess_field().
+ */
+function unl_five_preprocess_field(&$variables) {
+  // Search the text of text field types for usage of the 'unl-font-serif'.
+  // Load the 'unl_five_herbie/font-serif' library if found.
+  if (in_array($variables['field_type'], [
+    'text',
+    'text_long',
+    'text_with_summary',
+  ])) {
+    foreach ($variables['items'] as $item) {
+      if (strstr($item['content']['#text'], 'unl-font-serif')) {
+        $variables['#attached']['library'][] = 'unl_five/wdn-font-serif';
+        break;
+      }
+    }
+  }
+}
+
+/**
  * Implements template_preprocess_book_navigation().
  */
 function unl_five_preprocess_book_navigation(&$variables) {


### PR DESCRIPTION
In order for the UNL font-serif font to be loaded, a WDN JS plugin must be initiated: [Extended Fonts](https://wdn.unl.edu/documentation/5.0/javascript/extended-fonts)

> To load the optional brand serif font (Mercury Text), apply the `unl-font-serif` class to desired text, then add this snippet of JavaScript to either your page or your site's JavaScript:
> 
> ```HTML
> <script>
>   window.addEventListener('inlineJSReady', function() {
>     WDN.initializePlugin('font-serif');
>   }, false);
> </script>
> ```

This PR seeks to make that JS snippet available as a Drupal library (unl_five/wdn-font-serif) in the unl_five theme.

Then, the theme will use `template_preprocess_field()` to scan text field types for the 'unl-font-serif' string. If it's found, then the `unl_five/wdn-font-serif` library is loaded.