### PR TITLE
Add support for WDN 'scroll-animations' and 'card-as-link' JS plugins

### DIFF
--- a/js/wdn-card-as-link.js
+++ b/js/wdn-card-as-link.js
@@ -1,0 +1,21 @@
+/**
+ * @file
+ * Initiates WDN Card as Link.
+ */
+
+ (function (Drupal) {
+  Drupal.behaviors.wdnCardAsLink = {
+    attach: function attach(context, settings) {
+      // Check if WDN object is defined.
+      if ('undefined' !== typeof WDN) {
+        WDN.initializePlugin('card-as-link');
+      }
+      // If WDN object isn't defined, then wait for inlineJSReady event.
+      else {
+        window.addEventListener('inlineJSReady', function () {
+          WDN.initializePlugin('card-as-link');
+        }, false);
+      }
+    }
+  };
+})(Drupal);

--- a/js/wdn-scroll-animations.js
+++ b/js/wdn-scroll-animations.js
@@ -1,0 +1,21 @@
+/**
+ * @file
+ * Initiates WDN Scroll Animations.
+ */
+
+ (function (Drupal) {
+  Drupal.behaviors.wdnScrollAnimations = {
+    attach: function attach(context, settings) {
+      // Check if WDN object is defined.
+      if ('undefined' !== typeof WDN) {
+        WDN.initializePlugin('scroll-animations');
+      }
+      // If WDN object isn't defined, then wait for inlineJSReady event.
+      else {
+        window.addEventListener('inlineJSReady', function () {
+          WDN.initializePlugin('scroll-animations');
+        }, false);
+      }
+    }
+  };
+})(Drupal);

--- a/unl_five.libraries.yml
+++ b/unl_five.libraries.yml
@@ -48,3 +48,13 @@ wdn-font-serif:
   version: VERSION
   js:
     js/wdn-font-serif.js: {}
+
+wdn-scroll-animations:
+  version: VERSION
+  js:
+    js/wdn-scroll-animations.js: {}
+
+wdn-card-as-link:
+  version: VERSION
+  js:
+    js/wdn-card-as-link.js: {}


### PR DESCRIPTION
This PR seeks to make the WDN 'scroll-animations' and 'card-as-link' JS plugins available as Drupal libraries in the unl_five theme.