### PR TITLE
Move dcf-btn classes from menu local task <li> to <a>

### DIFF
--- a/templates/menu-local-task.html.twig
+++ b/templates/menu-local-task.html.twig
@@ -1,10 +1,8 @@
-{% set attributes = attributes.addClass('dcf-btn') %}
 {% if is_active %}
-  {% set attributes = attributes.addClass('dcf-btn-primary') %}
-  {% set options = { '#options': { 'attributes': { 'class': ['is-active', 'dcf-inverse'] }}} %}
-  {% set link = link|merge(options) %}
+  {% set options = { '#options': { 'attributes': { 'class': ['dcf-btn', 'dcf-btn-primary', 'is-active', 'dcf-inverse'] }}} %}
 {% else %}
-  {% set attributes = attributes.addClass('dcf-btn-secondary') %}
+  {% set options = { '#options': { 'attributes': { 'class': ['dcf-btn', 'dcf-btn-secondary'] }}} %}
 {% endif %}
+{% set link = link|merge(options) %}
 
 <li{{ attributes }}>{{ link }}</li>

--- a/templates/menu-local-tasks.html.twig
+++ b/templates/menu-local-tasks.html.twig
@@ -1,8 +1,8 @@
 {% if primary %}
   <h2 class="visually-hidden">{{ 'Primary tabs'|t }}</h2>
-  <ul class="cms-menu-local-tasks dcf-btn-group dcf-jc-flex-end dcf-flex-wrap-rev dcf-w-100% dcf-mb-0 dcf-pr-2 unl-scarlet dcf-bb-2 dcf-bb-solid dcf-bb-current dcf-txt-xs">{{ primary }}</ul>
+  <ul class="cms-menu-local-tasks dcf-list-bare dcf-btn-group dcf-jc-flex-end dcf-flex-wrap-rev dcf-w-100% dcf-mb-0 dcf-pr-2 unl-scarlet dcf-bb-2 dcf-bb-solid dcf-bb-current dcf-txt-xs">{{ primary }}</ul>
 {% endif %}
 {% if secondary %}
   <h2 class="visually-hidden">{{ 'Secondary tabs'|t }}</h2>
-  <ul class="cms-menu-local-tasks dcf-btn-group dcf-jc-flex-end dcf-flex-wrap-rev cf-w-100% dcf-mb-0 dcf-pr-2 unl-scarlet dcf-bb-2 dcf-bb-solid dcf-bb-current dcf-txt-xs">{{ secondary }}</ul>
+  <ul class="cms-menu-local-tasks dcf-list-bare dcf-btn-group dcf-jc-flex-end dcf-flex-wrap-rev cf-w-100% dcf-mb-0 dcf-pr-2 unl-scarlet dcf-bb-2 dcf-bb-solid dcf-bb-current dcf-txt-xs">{{ secondary }}</ul>
 {% endif %}


### PR DESCRIPTION
The current behavior is confusing. The tabs behaves like a button link; however, only clicking on the link itself will do anything. If a user clicks on the button but not on the link, it behaves like a link click; however, nothing happens. The entire button should be clickable.

The `dcf-btn` and the `dcf-btn-primary` classes are currently applied to the `<li>` element. They should be applied to the `<a>` element instead.

```html
<ul class="cms-menu-local-tasks dcf-btn-group dcf-jc-flex-end dcf-flex-wrap-rev dcf-w-100% dcf-mb-0 dcf-pr-2 unl-scarlet dcf-bb-2 dcf-bb-solid dcf-bb-current dcf-txt-xs">
  <li class="dcf-btn dcf-btn-primary">
    <a href="/hmed-home/" class="is-active dcf-inverse">View<span class="visually-hidden">(active tab)</span></a>
  </li>
</ul>
```