### PR TITLE
Accommodate string class value in unl_five_preprocess_form_element()

### DIFF
--- a/unl_five.theme
+++ b/unl_five.theme
@@ -334,8 +334,21 @@ function unl_five_preprocess_form_element(&$variables) {
   }
 
   // Add 'dcf-form-controls-inline' class as appropriate.
-  if (isset($variables['attributes']['class']) && in_array('webform-element--title-inline', $variables['attributes']['class'])) {
-    $variables['attributes']['class'][] = 'dcf-form-controls-inline';
+  if (isset($variables['attributes']['class'])) {
+    if (is_array($variables['attributes']['class'])
+      && in_array('webform-element--title-inline', $variables['attributes']['class'])
+      ) {
+
+      $variables['attributes']['class'][] = 'dcf-form-controls-inline';
+    }
+    // $variables['attributes']['class'] could also be a string.
+    else {
+      // Convert string value into an array value; preserve existing class.
+      $variables['attributes']['class'] = [
+        $variables['attributes']['class'],
+        'dcf-form-controls-inline',
+      ];
+    }
   }
 
   // Add 'dcf-form-help' class to descriptions.


### PR DESCRIPTION
`Warning: in_array() expects parameter 2 to be array, string given in unl_five_preprocess_form_element() (line 337 of /var/www/html/web/themes/contrib/unl_five/unl_five.theme)`

$variables['attributes']['class'] could also be a string.