### PR TITLE
Check if $variables['element']['#parents'] isset in unl_five_preprocess_form_element()

### DIFF
--- a/unl_five.theme
+++ b/unl_five.theme
@@ -365,7 +365,8 @@ function unl_five_preprocess_form_element(&$variables) {
     'webform_checkboxes_other',
     'radios',
   ];
-  if (empty(array_intersect($exempt_parents, $variables['element']['#parents']))) {
+  $parents = $variables['element']['#parents'] ?? [];
+  if (empty(array_intersect($exempt_parents, $parents))) {
     $variables['attributes']['class'][] = 'dcf-form-group';
   }
 
@@ -382,8 +383,9 @@ function unl_five_preprocess_form_element(&$variables) {
     'buttons',
     'buttons_other',
   ];
+  $parents = $variables['element']['#parents'] ?? [];
   if ($variables['type'] == 'radio') {
-    if (empty(array_intersect($button_parents, $variables['element']['#parents']))) {
+    if (empty(array_intersect($button_parents, $parents))) {
       $variables['attributes']['class'][] = 'dcf-input-radio';
     }
     else {


### PR DESCRIPTION
`Notice: Undefined index: #parents in unl_five_preprocess_form_element() (line 368 of /var/www/html/web/themes/contrib/unl_five/unl_five.theme)`

`Warning: array_intersect(): Expected parameter 2 to be an array, null given in unl_five_preprocess_form_element() (line 368 of /var/www/html/web/themes/contrib/unl_five/unl_five.theme)`

`$variables['element']['#parents']` may be not set. If it's not, then use an empty array for `array_intersect()`.

