### PR TITLE
Rearranged the site title logic for group pages to ensure the group homepage site title is not null

### DIFF
--- a/unl_five.theme
+++ b/unl_five.theme
@@ -39,15 +39,17 @@ function unl_five_preprocess(&$vars) {
 function unl_five_preprocess_html(&$variables) {
   $group = _unl_five_get_current_group();
 
-  // Swap head title variables for group.
+  // Swap head title variables for group. [Current Group Page | Group Label | Site Name | Nebraska]
   if ($group) {
     unset($variables['head_title']['name']);
-    if (_unl_five_is_request_group_front()) {
-      unset($variables['head_title']['title']);
-    } else {
-      $variables['head_title'] = array_slice($variables['head_title'], 0, 1, true) +
-        array('Group' => $group->label()) +
-        array_slice($variables['head_title'], 1, NULL, true);
+    // If we are not on the Group's front page (the meta tag module output works fine for group homepages).
+    if (!_unl_five_is_request_group_front()) {
+      $head_title_array = explode ("|", $variables['head_title']['title']);
+      $thirdFromEndIndex = $thirdFromEndIndex = count($head_title_array) - 2;
+      // Always add the group label before the site name and Nebraska (Tried creating a group and group relationship for the Meta tag module for this, but it wasn't working)
+      array_splice($head_title_array, $thirdFromEndIndex, 0, $group->label());
+      $head_title_array = implode(" | ", $head_title_array);
+      $variables['head_title']['title'] = $head_title_array;
     }
   }
 


### PR DESCRIPTION
Added this title format [Current Group Page | Group Label | Site Name | Nebraska] - Fixes #84. Fixes unlcms/project-herbie#840.

Closes #84 