### PR TITLE
Removed role="presentation" from the <li> tag 

### DIFF
--- a/templates/pager.html.twig
+++ b/templates/pager.html.twig
@@ -54,7 +54,9 @@
       {% endif %}
       {# Add an ellipsis if there are further previous pages. #}
       {% if ellipses.previous %}
-        <li class="pager__item pager__item--ellipsis" role="presentation">&hellip;</li>
+        <li class="pager__item pager__item--ellipsis">
+          <span aria-hidden="true">&hellip;</span>
+        </li>
       {% endif %}
       {# Now generate the actual pager piece. #}
       {% for key, item in items.pages %}
@@ -74,7 +76,9 @@
       {% endfor %}
       {# Add an ellipsis if there are further next pages. #}
       {% if ellipses.next %}
-        <li class="pager__item pager__item--ellipsis" role="presentation">&hellip;</li>
+        <li class="pager__item pager__item--ellipsis">
+          <span aria-hidden="true">&hellip;</span>
+        </li>
       {% endif %}
       {# Print next item if we are not on the last page. #}
       {% if items.next %}


### PR DESCRIPTION
Removed role="presentation" from the <li> tag and wrapped the ellipsis in a <span> with aria-hidden="true" instead. Fixes #86. Fixes https://github.com/unlcms/project-herbie/issues/972.

Closes #86 
Closes https://github.com/unlcms/project-herbie/issues/972